### PR TITLE
Add builtin ability to use JWTs in rpc client

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -159,24 +159,24 @@ func (op *requestOp) wait(ctx context.Context, c *Client) (*jsonrpcMessage, erro
 // For websocket connections, the origin is set to the local host name.
 //
 // The client reconnects automatically if the connection is lost.
-func Dial(rawurl string) (*Client, error) {
-	return DialContext(context.Background(), rawurl)
+func Dial(rawurl string, secret []byte) (*Client, error) {
+	return DialContext(context.Background(), rawurl, secret)
 }
 
 // DialContext creates a new RPC client, just like Dial.
 //
 // The context is used to cancel or time out the initial connection establishment. It does
 // not affect subsequent interactions with the client.
-func DialContext(ctx context.Context, rawurl string) (*Client, error) {
+func DialContext(ctx context.Context, rawurl string, secret []byte) (*Client, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err
 	}
 	switch u.Scheme {
 	case "http", "https":
-		return DialHTTP(rawurl)
+		return DialHTTP(rawurl, secret)
 	case "ws", "wss":
-		return DialWebsocket(ctx, rawurl, "")
+		return DialWebsocket(ctx, rawurl, "", secret)
 	case "stdio":
 		return DialStdIO(ctx)
 	case "":

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -705,9 +705,9 @@ func TestClientHTTPJwt(t *testing.T) {
 		)
 		switch transport {
 		case "http":
-			client, err = Dial(httpsrv.URL, secret)
+			client, err = DialJWT(ctx, httpsrv.URL, secret)
 		case "ws":
-			client, err = DialWebsocket(ctx, "ws"+wssrv.URL[4:], "*", secret)
+			client, err = DialJWT(ctx, "ws"+wssrv.URL[4:], secret)
 		}
 		if err != nil {
 			t.Fatal(err)

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -109,7 +109,7 @@ func TestHTTPRespBodyUnlimited(t *testing.T) {
 	ts := httptest.NewServer(s)
 	defer ts.Close()
 
-	c, err := DialHTTP(ts.URL)
+	c, err := DialHTTP(ts.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestHTTPErrorResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c, err := DialHTTP(ts.URL)
+	c, err := DialHTTP(ts.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/jwt.go
+++ b/rpc/jwt.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// IssueJwtToken creates a new token with IssuedAt set to time.Now().
+func IssueJwtToken() *jwt.Token {
+	claims := jwt.RegisteredClaims{IssuedAt: &jwt.NumericDate{time.Now()}}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+}
+
+// EncodeJwtAuthorization encodes the raw token string into HTTP header value format.
+func EncodeJwtAuthorization(strToken string) string {
+	return fmt.Sprintf("Bearer %v", strToken)
+}

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -36,7 +36,7 @@ import (
 func TestWebsocketClientHeaders(t *testing.T) {
 	t.Parallel()
 
-	endpoint, header, err := wsClientHeaders("wss://testuser:test-PASS_01@example.com:1234", "https://example.com")
+	endpoint, header, err := wsClientHeaders("wss://testuser:test-PASS_01@example.com:1234", "https://example.com", nil)
 	if err != nil {
 		t.Fatalf("wsGetConfig failed: %s", err)
 	}
@@ -63,7 +63,7 @@ func TestWebsocketOriginCheck(t *testing.T) {
 	defer srv.Stop()
 	defer httpsrv.Close()
 
-	client, err := DialWebsocket(context.Background(), wsURL, "http://ekzample.com")
+	client, err := DialWebsocket(context.Background(), wsURL, "http://ekzample.com", nil)
 	if err == nil {
 		client.Close()
 		t.Fatal("no error for wrong origin")
@@ -74,7 +74,7 @@ func TestWebsocketOriginCheck(t *testing.T) {
 	}
 
 	// Connections without origin header should work.
-	client, err = DialWebsocket(context.Background(), wsURL, "")
+	client, err = DialWebsocket(context.Background(), wsURL, "", nil)
 	if err != nil {
 		t.Fatalf("error for empty origin: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestWebsocketLargeCall(t *testing.T) {
 	defer srv.Stop()
 	defer httpsrv.Close()
 
-	client, err := DialWebsocket(context.Background(), wsURL, "")
+	client, err := DialWebsocket(context.Background(), wsURL, "", nil)
 	if err != nil {
 		t.Fatalf("can't dial: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestWebsocketPeerInfo(t *testing.T) {
 	defer ts.Close()
 
 	ctx := context.Background()
-	c, err := DialWebsocket(ctx, tsurl, "origin.example.com")
+	c, err := DialWebsocket(ctx, tsurl, "origin.example.com", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestClientWebsocketLargeMessage(t *testing.T) {
 	respLength := wsMessageSizeLimit - 50
 	srv.RegisterName("test", largeRespService{respLength})
 
-	c, err := DialWebsocket(context.Background(), wsURL, "")
+	c, err := DialWebsocket(context.Background(), wsURL, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +251,7 @@ func TestClientWebsocketSevered(t *testing.T) {
 	defer frontendProxy.Close()
 
 	wsURL := "ws:" + strings.TrimPrefix(frontendProxy.URL, "http:")
-	client, err := DialWebsocket(ctx, wsURL, "")
+	client, err := DialWebsocket(ctx, wsURL, "", nil)
 	if err != nil {
 		t.Fatalf("client dial error: %v", err)
 	}


### PR DESCRIPTION
Although it's possible to use set each request's header manually with `SetHeader`, this is a bit more pleasant to use. Curious to know your thoughts on extending the rpc client to support this. Currently implementing a CL mock in mergemock for authentication spec and so this is useful there. If you prefer to not merge something like this, I can make do with `SetHeader`.