### PR TITLE
Eof/extcall fixes

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -520,7 +520,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			st.gasRemaining = 0
 			st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
 		}
-		fmt.Println(vmerr)
 	} else {
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, value)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -512,7 +512,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		vmerr error // vm errors do not effect consensus and are therefore not assigned to err
 	)
 	if contractCreation {
-		ret, _, st.gasRemaining, vmerr = st.evm.Create(sender, msg.Data, st.gasRemaining, value)
+		ret, _, st.gasRemaining, vmerr = st.evm.Create(sender, msg.Data, st.gasRemaining, value, rules.IsPrague)
 		// Special case for EOF, if the initcode or deployed code is
 		// invalid, the tx is considered valid (so update nonce), but
 		// is to be treated as an exceptional abort (so burn all gas).

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -517,7 +517,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		// invalid, the tx is considered valid (so update nonce), but
 		// is to be treated as an exceptional abort (so burn all gas).
 		if errors.Is(vmerr, vm.ErrInvalidEOFInitcode) {
-			st.gasRemaining = 0
+			//st.gasRemaining = 0
 			st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
 		}
 	} else {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -517,7 +517,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		// invalid, the tx is considered valid (so update nonce), but
 		// is to be treated as an exceptional abort (so burn all gas).
 		if errors.Is(vmerr, vm.ErrInvalidEOFInitcode) {
-			//st.gasRemaining = 0
 			st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
 		}
 	} else {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -515,7 +515,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, _, st.gasRemaining, vmerr = st.evm.Create(sender, msg.Data, st.gasRemaining, value, rules.IsPrague)
 		// Special case for EOF, if the initcode or deployed code is
 		// invalid, the tx is considered valid (so update nonce), but
-		// is to be treated as an exceptional abort (so burn all gas).
+		// gas for initcode execution is not consumed.
+		// Only intrinsic creation transaction costs are charged.
 		if errors.Is(vmerr, vm.ErrInvalidEOFInitcode) {
 			st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
 		}

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -924,7 +924,6 @@ func opReturnContract(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 	}
 	ret := scope.Memory.GetPtr(offset.Uint64(), size.Uint64())
 	containerCode := scope.Contract.Container.ContainerCode[idx]
-	//deployedCode := append(containerCode, ret...)
 	if len(containerCode) == 0 {
 		return nil, errors.New("nonexistant subcontainer")
 	}

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -1073,7 +1073,7 @@ func opExtCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		ret, returnGas, err = interpreter.evm.Call(scope.Contract, toAddr, args, gas, &value)
 	}
 
-	if err == ErrExecutionReverted || err == ErrInsufficientBalance || err == ErrDepth {
+	if errors.Is(err, ErrExecutionReverted) || errors.Is(err, ErrInsufficientBalance) || errors.Is(err, ErrDepth) {
 		temp.SetOne()
 	} else if err != nil {
 		temp.SetUint64(2)

--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -145,10 +145,15 @@ func (c *Container) MarshalBinary() []byte {
 
 // UnmarshalBinary decodes an EOF container.
 func (c *Container) UnmarshalBinary(b []byte, isInitcode bool) error {
-	return c.unmarshalSubContainer(b, isInitcode, true)
+	return c.unmarshalContainer(b, isInitcode, true)
 }
 
-func (c *Container) unmarshalSubContainer(b []byte, isInitcode bool, topLevel bool) error {
+// UnmarshalSubContainer decodes an EOF container that is container in another container
+func (c *Container) UnmarshalSubContainer(b []byte, isInitcode bool) error {
+	return c.unmarshalContainer(b, isInitcode, false)
+}
+
+func (c *Container) unmarshalContainer(b []byte, isInitcode bool, topLevel bool) error {
 	if !hasEOFMagic(b) {
 		return fmt.Errorf("%w: want %x", ErrInvalidMagic, eofMagic)
 	}
@@ -294,7 +299,7 @@ func (c *Container) unmarshalSubContainer(b []byte, isInitcode bool, topLevel bo
 			}
 			c := new(Container)
 			end := min(idx+size, len(b))
-			if err := c.unmarshalSubContainer(b[idx:end], isInitcode, false); err != nil {
+			if err := c.unmarshalContainer(b[idx:end], isInitcode, false); err != nil {
 				if topLevel {
 					return fmt.Errorf("%w in sub container %d", err, i)
 				}

--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -245,7 +245,7 @@ func (c *Container) unmarshalContainer(b []byte, isInitcode bool, topLevel bool)
 		return fmt.Errorf("%w: have %d, want %d", ErrInvalidContainerSize, len(b), expectedSize)
 	}
 	// Only check that the expected size is not exceed on non-initcode
-	if !isInitcode && len(b) > expectedSize {
+	if (!topLevel || !isInitcode) && len(b) > expectedSize {
 		return fmt.Errorf("%w: have %d, want %d", ErrInvalidContainerSize, len(b), expectedSize)
 	}
 

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -42,7 +42,7 @@ var (
 	ErrInvalidEOFInitcode       = errors.New("invalid eof initcode")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
 	ErrInvalidNumberOfOutputs   = errors.New("invalid number of outputs")
-	ErrInvalidNonReturningFlag  = errors.New("Invalid non-returning flag, bad RETF")
+	ErrInvalidNonReturningFlag  = errors.New("invalid non-returning flag, bad RETF")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -571,7 +571,6 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// Reject code starting with 0xEF if EIP-3541 is enabled.
 	if err == nil && len(ret) >= 1 && HasEOFByte(ret) {
 		if evm.chainRules.IsPrague && isInitcodeEOF {
-			fmt.Printf("FIXME - valid EOF deployment\n")
 			// Don't reject EOF contracts after Shanghai
 		} else if evm.chainRules.IsLondon {
 			err = ErrInvalidCode

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
@@ -52,4 +53,33 @@ func callGas(isEip150 bool, availableGas, base uint64, callCost *uint256.Int) (u
 	}
 
 	return callCost.Uint64(), nil
+}
+
+// extCallGas returns the actual gas cost for ext*call operations.
+//
+// EOF v1 includes EIP-150 rules (all but 1/64) with a floor of MIN_RETAINED_GAS (5000)
+// and a minimum returned value of MIN_CALLE_GASS (2300).
+// There is also no call gas, so all available gas is used.
+//
+// If the minimum retained gas constraint is violated, zero gas and no error is returned
+func extCallGas(availableGas, base uint64) (uint64, error) {
+	if availableGas < base {
+		return 0, ErrOutOfGas
+	}
+	availableGas = availableGas - base
+	if availableGas < params.ExtCallMinRetainedGas {
+		return 0, nil
+	}
+
+	retainedGas := availableGas / 64
+	if retainedGas < params.ExtCallMinRetainedGas {
+		retainedGas = params.ExtCallMinRetainedGas
+	}
+	gas := availableGas - retainedGas
+
+	if gas < params.ExtCallMinCalleeGas {
+		return 0, nil
+	} else {
+		return gas, nil
+	}
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -715,7 +715,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 
 	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer, tracing.GasChangeCallContractCreation)
 
-	res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract, input, gas, &value)
+	res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract, input, gas, &value, false)
 	// Push item on the stack based on the returned error. If the ruleset is
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
 	// rule) and treat as an error, if the ruleset is frontier we must

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -180,7 +180,13 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	// - reset transient storage(eip 1153)
 	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
-	code, address, leftOverGas, err := vmenv.Create(sender, input, cfg.GasLimit, uint256.MustFromBig(cfg.Value), false)
+	code, address, leftOverGas, err := vmenv.Create(
+		sender,
+		input,
+		cfg.GasLimit,
+		uint256.MustFromBig(cfg.Value),
+		false,
+	)
 	return code, address, leftOverGas, err
 }
 

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -180,12 +180,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	// - reset transient storage(eip 1153)
 	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
-	code, address, leftOverGas, err := vmenv.Create(
-		sender,
-		input,
-		cfg.GasLimit,
-		uint256.MustFromBig(cfg.Value),
-	)
+	code, address, leftOverGas, err := vmenv.Create(sender, input, cfg.GasLimit, uint256.MustFromBig(cfg.Value), false)
 	return code, address, leftOverGas, err
 }
 

--- a/core/vm/validate.go
+++ b/core/vm/validate.go
@@ -155,9 +155,6 @@ func validateCode(code []byte, section int, container *Container, jt *JumpTable,
 			if ct := container.ContainerSections[arg]; len(ct.Data) != ct.DataSize {
 				return nil, fmt.Errorf("%w: container %d, have %d, claimed %d, pos %d", ErrEOFCreateWithTruncatedSection, arg, len(ct.Data), ct.DataSize, i)
 			}
-			if _, ok := visitedSubcontainers[arg]; ok {
-				return nil, fmt.Errorf("section already referenced, arg :%d", arg)
-			}
 			// We need to store per subcontainer how it was referenced
 			if v, ok := visitedSubcontainers[arg]; ok && v != RefByEOFCreate {
 				return nil, fmt.Errorf("section already referenced, arg :%d", arg)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -89,6 +89,8 @@ const (
 	CreateNGasEip4762     uint64 = 1000  // Once per CREATEn operations post-verkle
 	SelfdestructRefundGas uint64 = 24000 // Refunded following a selfdestruct operation.
 	MemoryGas             uint64 = 3     // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL.
+	ExtCallMinRetainedGas uint64 = 5000  // For EXT*CALL this is the minimum gas that the EIp158 1/64th rule must retain
+	ExtCallMinCalleeGas   uint64 = 2300  // For EXT*CALL this is the minimum gas that must be passed to the callee, ignoring 63/64
 
 	TxDataNonZeroGasFrontier  uint64 = 68   // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
 	TxDataNonZeroGasEIP2028   uint64 = 16   // Per byte of non zero data attached to a transaction after EIP 2028 (part in Istanbul)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -259,10 +259,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	vmconfig.ExtraEips = eips
 
 	block := t.genesis(config).ToBlock()
-	genesisAlloc := t.json.Pre
-	genesisAlloc[params.BeaconRootsAddress] = types.Account{Nonce: 1, Code: params.BeaconRootsCode}
-	//genesisAlloc[params.HistoryStorageAddress] = types.Account{Nonce: 1, Code: params.HistoryStorageCode}
-	st = MakePreState(rawdb.NewMemoryDatabase(), genesisAlloc, snapshotter, scheme)
+	st = MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre, snapshotter, scheme)
 
 	var baseFee *big.Int
 	if config.IsLondon(new(big.Int)) {
@@ -318,10 +315,6 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	}
 	if config.IsCancun(new(big.Int), block.Time()) && t.json.Env.ExcessBlobGas != nil {
 		context.BlobBaseFee = eip4844.CalcBlobFee(*t.json.Env.ExcessBlobGas)
-	}
-	{
-		evm := vm.NewEVM(context, vm.TxContext{}, st.StateDB, config, vmconfig)
-		core.ProcessBeaconBlockRoot(common.HexToHash("0x00"), evm, st.StateDB)
 	}
 
 	evm := vm.NewEVM(context, txContext, st.StateDB, config, vmconfig)


### PR DESCRIPTION
* remove unneeded printlns that get in the way of EEST fills
* use correct stack heights for value and address in EXTCALL
* New extCallGas function that handles min retained and min callee gas
* Handle min gas failures via tempCallGas == 0
* remove stipend refund for EXT*CALL
* Call Stack too deep should return 1
* Update aux data handling in EOFCREATE
* Add flag to allow EOF from contract creation transactions