### PR TITLE
Restore state test transaction context

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -249,6 +249,7 @@ func ProcessParentBlockHash(prevHash common.Hash, vmenv *vm.EVM, statedb *state.
 		}
 	}
 
+	oldContext := vmenv.TxContext
 	msg := &Message{
 		From:      params.SystemAddress,
 		GasLimit:  30_000_000,
@@ -262,6 +263,7 @@ func ProcessParentBlockHash(prevHash common.Hash, vmenv *vm.EVM, statedb *state.
 	statedb.AddAddressToAccessList(params.HistoryStorageAddress)
 	_, _, _ = vmenv.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
 	statedb.Finalise(true)
+	vmenv.Reset(oldContext, statedb)
 }
 
 // ParseDepositLogs extracts the EIP-6110 deposit values from logs emitted by

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -249,7 +249,6 @@ func ProcessParentBlockHash(prevHash common.Hash, vmenv *vm.EVM, statedb *state.
 		}
 	}
 
-	oldContext := vmenv.TxContext
 	msg := &Message{
 		From:      params.SystemAddress,
 		GasLimit:  30_000_000,
@@ -263,7 +262,6 @@ func ProcessParentBlockHash(prevHash common.Hash, vmenv *vm.EVM, statedb *state.
 	statedb.AddAddressToAccessList(params.HistoryStorageAddress)
 	_, _, _ = vmenv.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
 	statedb.Finalise(true)
-	vmenv.Reset(oldContext, statedb)
 }
 
 // ParseDepositLogs extracts the EIP-6110 deposit values from logs emitted by

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -299,11 +299,13 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 		tracer.OnTxStart(evm.GetVMContext(), nil, msg.From)
 	}
 
+	oldContext := evm.TxContext
 	if config.IsPrague(new(big.Int), 0) {
 		for i := int(block.Number().Uint64() - 1); i >= 0; i-- {
 			core.ProcessParentBlockHash(vmTestBlockHash(uint64(i)), evm, st.StateDB)
 		}
 	}
+	evm.Reset(oldContext, st.StateDB)
 
 	// Execute the message.
 	snapshot := st.StateDB.Snapshot()


### PR DESCRIPTION
In state tests when running prague system contracts the origin remains as the system account. Restore the prior tx context after running system contracts.