### PR TITLE
Rename `cellProofs` response field of GetBlobsV2 to `proofs`

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -125,7 +125,7 @@ type BlobAndProofV1 struct {
 
 type BlobAndProofV2 struct {
 	Blob       hexutil.Bytes   `json:"blob"`
-	CellProofs []hexutil.Bytes `json:"cellProofs"`
+	CellProofs []hexutil.Bytes `json:"proofs"`
 }
 
 // JSON type overrides for ExecutionPayloadEnvelope.


### PR DESCRIPTION
While running devnets for peerdas, I noticed that the `cellProofs` field for `getBlobsV2` has to be `proofs` according to the new spec: https://github.com/ethereum/execution-apis/pull/630/files#diff-4b9ffe71c6b2ca7b9b6591fe9c2c0ebf8a55b52e5cbcff02b051cfdcd939f31bR43

I tested this with latest peerdas lighthouse/grandine implementation in a devnet. 

This PR is a simple renaming in the json response to fix this! :+1: I could also modify the variable name to `Proofs` as well, but I'd like to defer that to your preference :) 