### PR TITLE
Add Unified EL metrics for GetBlobsV2

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1325,19 +1325,6 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash) []*types.BlobTxSidecar {
 	return sidecars
 }
 
-func (p *BlobPool) HasBlobs(vhashes []common.Hash) bool {
-	for _, vhash := range vhashes {
-		// Retrieve the datastore item (in a short lock)
-		p.lock.RLock()
-		_, exists := p.lookup.storeidOfBlob(vhash)
-		p.lock.RUnlock()
-		if !exists {
-			return false
-		}
-	}
-	return true
-}
-
 func (p *BlobPool) GetBlobCounts(vhashes []common.Hash) int {
 	count := 0
 	for _, vhash := range vhashes {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1338,6 +1338,20 @@ func (p *BlobPool) HasBlobs(vhashes []common.Hash) bool {
 	return true
 }
 
+func (p *BlobPool) GetBlobCounts(vhashes []common.Hash) int {
+	count := 0
+	for _, vhash := range vhashes {
+		// Retrieve the datastore item (in a short lock)
+		p.lock.RLock()
+		_, exists := p.lookup.storeidOfBlob(vhash)
+		p.lock.RUnlock()
+		if exists {
+			count += 1
+		}
+	}
+	return count
+}
+
 // Add inserts a set of blob transactions into the pool if they pass validation (both
 // consensus validity and pool restrictions).
 //

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1068,12 +1068,6 @@ func (pool *LegacyPool) GetBlobs(vhashes []common.Hash) []*types.BlobTxSidecar {
 	return nil
 }
 
-// HasBlobs is not supported by the legacy transaction pool, it is just here to
-// implement the txpool.SubPool interface.
-func (pool *LegacyPool) HasBlobs(vhashes []common.Hash) bool {
-	return false
-}
-
 // GetBlobCounts returns number of blobs in the subpool that matches the given
 // versioned hashes, without performing db read.
 func (pool *LegacyPool) GetBlobCounts(vhashes []common.Hash) int {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1074,6 +1074,12 @@ func (pool *LegacyPool) HasBlobs(vhashes []common.Hash) bool {
 	return false
 }
 
+// GetBlobCounts returns number of blobs in the subpool that matches the given
+// versioned hashes, without performing db read.
+func (pool *LegacyPool) GetBlobCounts(vhashes []common.Hash) int {
+	return 0
+}
+
 // Has returns an indicator whether txpool has a transaction cached with the
 // given hash.
 func (pool *LegacyPool) Has(hash common.Hash) bool {

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -141,6 +141,10 @@ type SubPool interface {
 	// are in the sub pool.
 	HasBlobs(vhashes []common.Hash) bool
 
+	// GetBlobCounts returns number of blobs in the subpool that matches the given
+	// versioned hashes, without performing db read.
+	GetBlobCounts(vhashes []common.Hash) int
+
 	// ValidateTxBasics checks whether a transaction is valid according to the consensus
 	// rules, but does not check state-dependent validation such as sufficient balance.
 	// This check is meant as a static check which can be performed without holding the

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -137,10 +137,6 @@ type SubPool interface {
 	// retrieve blobs from the pools directly instead of the network.
 	GetBlobs(vhashes []common.Hash) []*types.BlobTxSidecar
 
-	// HasBlobs returns true if all blobs corresponding to the versioned hashes
-	// are in the sub pool.
-	HasBlobs(vhashes []common.Hash) bool
-
 	// GetBlobCounts returns number of blobs in the subpool that matches the given
 	// versioned hashes, without performing db read.
 	GetBlobCounts(vhashes []common.Hash) int

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -334,20 +334,6 @@ func (p *TxPool) GetBlobCounts(vhashes []common.Hash) int {
 	return 0
 }
 
-// HasBlobs will return true if all the vhashes are available in the same subpool.
-func (p *TxPool) HasBlobs(vhashes []common.Hash) bool {
-	for _, subpool := range p.subpools {
-		// It's an ugly to assume that only one pool will be capable of returning
-		// anything meaningful for this call, but anything else requires merging
-		// partial responses and that's too annoying to do until we get a second
-		// blobpool (probably never).
-		if subpool.HasBlobs(vhashes) {
-			return true
-		}
-	}
-	return false
-}
-
 // ValidateTxBasics checks whether a transaction is valid according to the consensus
 // rules, but does not check state-dependent validation such as sufficient balance.
 func (p *TxPool) ValidateTxBasics(tx *types.Transaction) error {

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -323,6 +323,17 @@ func (p *TxPool) GetBlobs(vhashes []common.Hash) []*types.BlobTxSidecar {
 	return nil
 }
 
+// GetBlobCounts returns a number of blobs that are present in the txpool for
+// the given versioned hashes.
+func (p *TxPool) GetBlobCounts(vhashes []common.Hash) int {
+	for _, subpool := range p.subpools {
+		if count := subpool.GetBlobCounts(vhashes); count != 0 {
+			return count
+		}
+	}
+	return 0
+}
+
 // HasBlobs will return true if all the vhashes are available in the same subpool.
 func (p *TxPool) HasBlobs(vhashes []common.Hash) bool {
 	for _, subpool := range p.subpools {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -165,7 +165,7 @@ var (
 	// Number of blobs requested via getBlobsV2
 	getBlobsV2BlobsRequestedTotal = metrics.NewRegisteredCounter("get_blobs_requests_blobs_total", nil)
 	// Number of blobs requested via getBlobsV2 that are present in the blobpool
-	getBlobsV2BlobsInPoolTottal = metrics.NewRegisteredCounter("get_blobs_requests_blobs_in_blobpool_total", nil)
+	getBlobsV2BlobsInPoolTotal = metrics.NewRegisteredCounter("get_blobs_requests_blobs_in_blobpool_total", nil)
 	// Number of times getBlobsV2 responded with “hit”
 	getBlobsV2RequestHit = metrics.NewRegisteredCounter("get_blobs_requests_success_total", nil)
 	// Number of times getBlobsV2 responded with “miss”
@@ -598,7 +598,7 @@ func (api *ConsensusAPI) GetBlobsV2(hashes []common.Hash) ([]*engine.BlobAndProo
 
 	// Optimization: check first if all blobs are available, if not, return empty response
 	blobCounts := api.eth.TxPool().GetBlobCounts(hashes)
-	getBlobsV2BlobsInPoolTottal.Inc(int64(blobCounts))
+	getBlobsV2BlobsInPoolTotal.Inc(int64(blobCounts))
 
 	if blobCounts == len(hashes) {
 		getBlobsV2RequestHit.Inc(1)


### PR DESCRIPTION
This PR adds unified metrics across different ELs for the new GetBlobsV2 Engine API that is WIP in PR #63.

I've been working on implementing these metrics across different ELs with Minhyuk from Sunnyside Labs. This is initiated to gather something in common between ELs for devnet tests. You can find our proposal here https://testinprod.notion.site/Proposal-for-Unified-EL-metrics-for-PeerDAS-1d28fc57f54680f2a3cbfe408d7db4b8?pvs=4.