### PR TITLE
core/vm: fix GasCosts bugs in EIP-8037 multidimensional gas metering

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -117,6 +117,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Set
 	}
 	if authList != nil {
 		if rules.IsAmsterdam {
+			gas.RegularGas += uint64(len(authList)) * params.TxAuthBaseGas
 			gas.StateGas += uint64(len(authList)) * (params.AccountCreationSize + params.AuthorizationCreationSize) * costPerStateByte
 		} else {
 			gas.RegularGas += uint64(len(authList)) * params.CallNewAccountGas

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -117,7 +117,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Set
 	}
 	if authList != nil {
 		if rules.IsAmsterdam {
-			gas.StateGas += uint64(len(authList)) * costPerStateByte
+			gas.StateGas += uint64(len(authList)) * (params.AccountCreationSize + params.AuthorizationCreationSize) * costPerStateByte
 		} else {
 			gas.RegularGas += uint64(len(authList)) * params.CallNewAccountGas
 		}

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -582,7 +582,9 @@ func enable7702(jt *JumpTable) {
 }
 
 func enable8037(jt *JumpTable) {
+	jt[CREATE].constantGas = 0
 	jt[CREATE].dynamicGas = gasCreateEip8037
+	jt[CREATE2].constantGas = 0
 	jt[CREATE2].dynamicGas = gasCreate2Eip8037
 	jt[CALL].dynamicGas = gasCall8037
 	jt[SELFDESTRUCT].dynamicGas = gasSelfdestruct8037

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -593,7 +593,9 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 	if !evm.chainRules.IsEIP4762 {
 		createDataGas := GasCosts{RegularGas: uint64(len(ret)) * params.CreateDataGas}
 		if evm.chainRules.IsAmsterdam {
-			createDataGas = GasCosts{StateGas: uint64(len(ret)) * evm.Context.CostPerGasByte}
+			// State gas for code bytes + regular gas for keccak256 hash cost
+			codeHashGas := params.Keccak256WordGas * ((uint64(len(ret)) + 31) / 32)
+			createDataGas = GasCosts{RegularGas: codeHashGas, StateGas: uint64(len(ret)) * evm.Context.CostPerGasByte}
 		}
 		if !contract.UseGas(createDataGas, evm.Config.Tracer, tracing.GasChangeCallCodeStorage) {
 			return ret, ErrCodeStoreOutOfGas

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -605,14 +605,14 @@ func gasSStore8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 	}
 	if original == current {
 		if original == (common.Hash{}) { // create slot (2.1.1)
-			return GasCosts{RegularGas: cost.RegularGas, StateGas: params.StorageCreationSize * evm.Context.CostPerGasByte}, nil
+			return GasCosts{RegularGas: cost.RegularGas + params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929, StateGas: params.StorageCreationSize * evm.Context.CostPerGasByte}, nil
 		}
 		if value == (common.Hash{}) { // delete slot (2.1.2b)
 			evm.StateDB.AddRefund(params.SstoreClearsScheduleRefundEIP3529)
 		}
 		// EIP-2200 original clause:
 		//		return params.SstoreResetGasEIP2200, nil // write existing slot (2.1.2)
-		return GasCosts{RegularGas: cost.RegularGas, StateGas: params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929}, nil // write existing slot (2.1.2)
+		return GasCosts{RegularGas: cost.RegularGas + params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929}, nil // write existing slot (2.1.2)
 	}
 	if original != (common.Hash{}) {
 		if current == (common.Hash{}) { // recreate slot (2.2.1.1)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -625,7 +625,7 @@ func gasSStore8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 		if original == (common.Hash{}) { // reset to original inexistent slot (2.2.2.1)
 			// EIP 2200 Original clause:
 			//evm.StateDB.AddRefund(params.SstoreSetGasEIP2200 - params.SloadGasEIP2200)
-			evm.StateDB.AddRefund(params.StorageCreationSize*evm.Context.CostPerGasByte - params.WarmStorageReadCostEIP2929)
+			evm.StateDB.AddRefund(params.StorageCreationSize * evm.Context.CostPerGasByte)
 		} else { // reset to original existing slot (2.2.2.2)
 			// EIP 2200 Original clause:
 			//	evm.StateDB.AddRefund(params.SstoreResetGasEIP2200 - params.SloadGasEIP2200)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -502,8 +502,9 @@ func gasCreateEip8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 		return GasCosts{}, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
-	moreGas := params.AccountCreationSize * evm.Context.CostPerGasByte * ((size + 31) / 32)
-	return GasCosts{RegularGas: gas, StateGas: moreGas}, nil
+	wordGas := params.InitCodeWordGas * ((size + 31) / 32)
+	stateGas := params.AccountCreationSize * evm.Context.CostPerGasByte
+	return GasCosts{RegularGas: gas + wordGas, StateGas: stateGas}, nil
 }
 
 func gasCreate2Eip8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (GasCosts, error) {
@@ -519,8 +520,9 @@ func gasCreate2Eip8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 		return GasCosts{}, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
-	moreGas := (params.AccountCreationSize*evm.Context.CostPerGasByte + params.Keccak256WordGas) * ((size + 31) / 32)
-	return GasCosts{RegularGas: gas, StateGas: moreGas}, nil
+	wordGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ((size + 31) / 32)
+	stateGas := params.AccountCreationSize * evm.Context.CostPerGasByte
+	return GasCosts{RegularGas: gas + wordGas, StateGas: stateGas}, nil
 }
 
 func gasCall8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (GasCosts, error) {

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -504,7 +504,7 @@ func gasCreateEip8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
 	wordGas := params.InitCodeWordGas * ((size + 31) / 32)
 	stateGas := params.AccountCreationSize * evm.Context.CostPerGasByte
-	return GasCosts{RegularGas: gas + wordGas, StateGas: stateGas}, nil
+	return GasCosts{RegularGas: gas + wordGas + params.ColdAccountAccessCostEIP2929, StateGas: stateGas}, nil
 }
 
 func gasCreate2Eip8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (GasCosts, error) {
@@ -522,7 +522,7 @@ func gasCreate2Eip8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
 	wordGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ((size + 31) / 32)
 	stateGas := params.AccountCreationSize * evm.Context.CostPerGasByte
-	return GasCosts{RegularGas: gas + wordGas, StateGas: stateGas}, nil
+	return GasCosts{RegularGas: gas + wordGas + params.ColdAccountAccessCostEIP2929, StateGas: stateGas}, nil
 }
 
 func gasCall8037(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (GasCosts, error) {

--- a/core/vm/gascosts.go
+++ b/core/vm/gascosts.go
@@ -9,33 +9,26 @@ func (g GasCosts) Max() uint64 {
 	return max(g.RegularGas, g.StateGas)
 }
 
-// Sub returns true if the operation would underflow
 func (g GasCosts) Underflow(b GasCosts) bool {
-	if b.RegularGas > g.RegularGas {
-		return true
-	}
+	stateOverflow := uint64(0)
 	if b.StateGas > g.StateGas {
-		if b.StateGas > g.RegularGas {
-			return true
-		}
+		stateOverflow = b.StateGas - g.StateGas
 	}
-	return false
+	return b.RegularGas+stateOverflow > g.RegularGas
 }
 
-// Sub doesn't check for underflows
-func (g GasCosts) Sub(b GasCosts) {
+func (g *GasCosts) Sub(b GasCosts) {
 	g.RegularGas -= b.RegularGas
 	if b.StateGas > g.StateGas {
 		diff := b.StateGas - g.StateGas
 		g.StateGas = 0
 		g.RegularGas -= diff
 	} else {
-		g.StateGas -= b.RegularGas
+		g.StateGas -= b.StateGas
 	}
 }
 
-// Add doesn't check for overflows
-func (g GasCosts) Add(b GasCosts) {
+func (g *GasCosts) Add(b GasCosts) {
 	g.RegularGas += b.RegularGas
-	g.StateGas += b.RegularGas
+	g.StateGas += b.StateGas
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -188,6 +188,7 @@ const (
 	AccountCreationSize       = 112
 	StorageCreationSize       = 32
 	AuthorizationCreationSize = 23
+	TxAuthBaseGas             = 7500
 )
 
 // Bls12381G1MultiExpDiscountTable is the gas discount table for BLS12-381 G1 multi exponentiation operation


### PR DESCRIPTION
1. Use pointer receivers for Sub() and Add() methods. Value receivers caused modifications to be lost since Go passes structs by value.

2. Fix Sub() to deduct b.StateGas (not b.RegularGas) from g.StateGas when the reservoir has sufficient funds.

3. Fix Underflow() to account for combined demand on RegularGas. When state gas overflows from the reservoir, it competes with regular gas for the common pool. The old check missed cases where b.RegularGas + stateOverflow > g.RegularGas.

4. Fix Add() to add b.StateGas (not b.RegularGas) to g.StateGas