### PR TITLE
fix: testing_buildBlockV1, deterministic access list, console test

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -213,7 +213,7 @@ func encodeTransactions(txs []*types.Transaction) [][]byte {
 	return enc
 }
 
-func decodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
+func DecodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
 	var txs = make([]*types.Transaction, len(enc))
 	for i, encTx := range enc {
 		var tx types.Transaction
@@ -251,7 +251,7 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 // for stateless execution, so it skips checking if the executable data hashes to
 // the requested hash (stateless has to *compute* the root hash, it's not given).
 func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash, requests [][]byte) (*types.Block, error) {
-	txs, err := decodeTransactions(data.Transactions)
+	txs, err := DecodeTransactions(data.Transactions)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -280,6 +280,8 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 	}
 	utils.RegisterSyncOverrideService(stack, eth, synctarget, ctx.Bool(utils.ExitWhenSyncedFlag.Name))
 
+	catalyst.RegisterTestingAPI(stack, eth)
+
 	if ctx.IsSet(utils.DeveloperFlag.Name) {
 		// Start dev mode.
 		simBeacon, err := catalyst.NewSimulatedBeacon(ctx.Uint64(utils.DeveloperPeriodFlag.Name), cfg.Eth.Miner.PendingFeeRecipient, eth)

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 testing:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -53,11 +53,6 @@ func Register(stack *node.Node, backend *eth.Ethereum) error {
 			Service:       NewConsensusAPI(backend),
 			Authenticated: true,
 		},
-		{
-			Namespace:     "testing",
-			Service:       NewTestingAPI(backend),
-			Authenticated: true,
-		},
 	})
 	return nil
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -53,6 +53,11 @@ func Register(stack *node.Node, backend *eth.Ethereum) error {
 			Service:       NewConsensusAPI(backend),
 			Authenticated: true,
 		},
+		{
+			Namespace:     "testing",
+			Service:       NewTestingAPI(backend),
+			Authenticated: true,
+		},
 	})
 	return nil
 }

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -1,0 +1,44 @@
+package catalyst
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/miner"
+)
+
+type TestingAPI struct {
+	eth *eth.Ethereum
+}
+
+func NewTestingAPI(eth *eth.Ethereum) *TestingAPI {
+	return &TestingAPI{
+		eth: eth,
+	}
+}
+
+func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []*types.Transaction, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
+	if api.eth.BlockChain().CurrentBlock().Hash() != parentHash {
+		return nil, errors.New("parentHash is not current head")
+	}
+	args := &miner.BuildPayloadArgs{
+		Parent:       parentHash,
+		Timestamp:    payloadAttributes.Timestamp,
+		FeeRecipient: payloadAttributes.SuggestedFeeRecipient,
+		Random:       payloadAttributes.Random,
+		Withdrawals:  payloadAttributes.Withdrawals,
+		BeaconRoot:   payloadAttributes.BeaconRoot,
+		Transactions: transactions,
+		ExtraData:    extraData,
+	}
+	payload, err := api.eth.Miner().BuildPayload(args, false)
+	if err != nil {
+		log.Error("Failed to build payload", "err", err)
+		return nil, err
+	}
+	return payload.ResolveFull(), nil
+}

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
@@ -32,11 +33,15 @@ func RegisterTestingAPI(stack *node.Node, backend *eth.Ethereum) error {
 	return nil
 }
 
-func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions [][]byte, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
+func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []hexutil.Bytes, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
 	if api.eth.BlockChain().CurrentBlock().Hash() != parentHash {
 		return nil, errors.New("parentHash is not current head")
 	}
-	txs, err := engine.DecodeTransactions(transactions)
+	dec := make([][]byte, 0, len(transactions))
+	for _, tx := range transactions {
+		dec = append(dec, tx)
+	}
+	txs, err := engine.DecodeTransactions(dec)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -33,7 +33,7 @@ func RegisterTestingAPI(stack *node.Node, backend *eth.Ethereum) error {
 	return nil
 }
 
-func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []hexutil.Bytes, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
+func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []hexutil.Bytes, extraData hexutil.Bytes) (*engine.ExecutionPayloadEnvelope, error) {
 	if api.eth.BlockChain().CurrentBlock().Hash() != parentHash {
 		return nil, errors.New("parentHash is not current head")
 	}

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
@@ -33,9 +32,13 @@ func RegisterTestingAPI(stack *node.Node, backend *eth.Ethereum) error {
 	return nil
 }
 
-func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []*types.Transaction, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
+func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions [][]byte, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
 	if api.eth.BlockChain().CurrentBlock().Hash() != parentHash {
 		return nil, errors.New("parentHash is not current head")
+	}
+	txs, err := engine.DecodeTransactions(transactions)
+	if err != nil {
+		return nil, err
 	}
 	args := &miner.BuildPayloadArgs{
 		Parent:       parentHash,
@@ -44,7 +47,7 @@ func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 		Random:       payloadAttributes.Random,
 		Withdrawals:  payloadAttributes.Withdrawals,
 		BeaconRoot:   payloadAttributes.BeaconRoot,
-		Transactions: transactions,
+		Transactions: txs,
 		ExtraData:    extraData,
 	}
 	payload, err := api.eth.Miner().BuildPayload(args, false)

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type TestingAPI struct {
@@ -19,6 +21,16 @@ func NewTestingAPI(eth *eth.Ethereum) *TestingAPI {
 	return &TestingAPI{
 		eth: eth,
 	}
+}
+
+func RegisterTestingAPI(stack *node.Node, backend *eth.Ethereum) error {
+	stack.RegisterAPIs([]rpc.API{{
+		Namespace:     "testing",
+		Service:       NewTestingAPI(backend),
+		Authenticated: false,
+	},
+	})
+	return nil
 }
 
 func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []*types.Transaction, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -33,7 +33,7 @@ func RegisterTestingAPI(stack *node.Node, backend *eth.Ethereum) error {
 	return nil
 }
 
-func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []hexutil.Bytes, extraData hexutil.Bytes) (*engine.ExecutionPayloadEnvelope, error) {
+func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []hexutil.Bytes, extraData *hexutil.Bytes) (*engine.ExecutionPayloadEnvelope, error) {
 	if api.eth.BlockChain().CurrentBlock().Hash() != parentHash {
 		return nil, errors.New("parentHash is not current head")
 	}
@@ -45,6 +45,10 @@ func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 	if err != nil {
 		return nil, err
 	}
+	extra := []byte{}
+	if extraData != nil {
+		extra = *extraData
+	}
 	args := &miner.BuildPayloadArgs{
 		Parent:       parentHash,
 		Timestamp:    payloadAttributes.Timestamp,
@@ -53,7 +57,7 @@ func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 		Withdrawals:  payloadAttributes.Withdrawals,
 		BeaconRoot:   payloadAttributes.BeaconRoot,
 		Transactions: txs,
-		ExtraData:    extraData,
+		ExtraData:    extra,
 	}
 	payload, err := api.eth.Miner().BuildPayload(args, false)
 	if err != nil {

--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -50,14 +50,16 @@ func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 		extra = *extraData
 	}
 	args := &miner.BuildPayloadArgs{
-		Parent:       parentHash,
-		Timestamp:    payloadAttributes.Timestamp,
-		FeeRecipient: payloadAttributes.SuggestedFeeRecipient,
-		Random:       payloadAttributes.Random,
-		Withdrawals:  payloadAttributes.Withdrawals,
-		BeaconRoot:   payloadAttributes.BeaconRoot,
-		Transactions: txs,
-		ExtraData:    extra,
+		Parent:           parentHash,
+		Timestamp:        payloadAttributes.Timestamp,
+		FeeRecipient:     payloadAttributes.SuggestedFeeRecipient,
+		Random:           payloadAttributes.Random,
+		Withdrawals:      payloadAttributes.Withdrawals,
+		BeaconRoot:       payloadAttributes.BeaconRoot,
+		Transactions:     txs,
+		ExtraData:        extra,
+		OnlyProvidedTxs:  true, // testing_buildBlockV1: use only given transactions, no mempool
+		UseExplicitExtra: true, // testing_buildBlockV1: use given extraData verbatim (including 0x when null)
 	}
 	payload, err := api.eth.Miner().BuildPayload(args, false)
 	if err != nil {

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -17,7 +17,9 @@
 package logger
 
 import (
+	"bytes"
 	"maps"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -81,14 +83,22 @@ func (al accessList) equal(other accessList) bool {
 }
 
 // accessList converts the accesslist to a types.AccessList.
+// Addresses and storage keys are sorted so the result is deterministic (e.g. for eth_createAccessList fixtures).
 func (al accessList) accessList() types.AccessList {
+	addrs := make([]common.Address, 0, len(al))
+	for addr := range al {
+		addrs = append(addrs, addr)
+	}
+	sort.Slice(addrs, func(i, j int) bool { return bytes.Compare(addrs[i][:], addrs[j][:]) < 0 })
 	acl := make(types.AccessList, 0, len(al))
-	for addr, slots := range al {
-		tuple := types.AccessTuple{Address: addr, StorageKeys: []common.Hash{}}
+	for _, addr := range addrs {
+		slots := al[addr]
+		keys := make([]common.Hash, 0, len(slots))
 		for slot := range slots {
-			tuple.StorageKeys = append(tuple.StorageKeys, slot)
+			keys = append(keys, slot)
 		}
-		acl = append(acl, tuple)
+		sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+		acl = append(acl, types.AccessTuple{Address: addr, StorageKeys: keys})
 	}
 	return acl
 }

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -17,9 +17,8 @@
 package logger
 
 import (
-	"bytes"
 	"maps"
-	"sort"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -85,21 +84,12 @@ func (al accessList) equal(other accessList) bool {
 // accessList converts the accesslist to a types.AccessList.
 // Addresses and storage keys are sorted so the result is deterministic (e.g. for eth_createAccessList fixtures).
 func (al accessList) accessList() types.AccessList {
-	addrs := make([]common.Address, 0, len(al))
-	for addr := range al {
-		addrs = append(addrs, addr)
-	}
-	sort.Slice(addrs, func(i, j int) bool { return bytes.Compare(addrs[i][:], addrs[j][:]) < 0 })
 	acl := make(types.AccessList, 0, len(al))
-	for _, addr := range addrs {
-		slots := al[addr]
-		keys := make([]common.Hash, 0, len(slots))
-		for slot := range slots {
-			keys = append(keys, slot)
-		}
-		sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+	for addr, slots := range al {
+		keys := slices.SortedFunc(maps.Keys(slots), common.Hash.Cmp)
 		acl = append(acl, types.AccessTuple{Address: addr, StorageKeys: keys})
 	}
+	slices.SortFunc(acl, func(a, b types.AccessTuple) int { return a.Address.Cmp(b.Address) })
 	return acl
 }
 

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -17,9 +17,11 @@
 package override
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -58,9 +60,17 @@ func (diff *StateOverride) Apply(statedb *state.StateDB, precompiles vm.Precompi
 	if diff == nil {
 		return nil
 	}
+	// Iterate in deterministic order so error messages and behavior are stable (e.g. for tests).
+	addrs := make([]common.Address, 0, len(*diff))
+	for addr := range *diff {
+		addrs = append(addrs, addr)
+	}
+	sort.Slice(addrs, func(i, j int) bool { return bytes.Compare(addrs[i][:], addrs[j][:]) < 0 })
+
 	// Tracks destinations of precompiles that were moved.
 	dirtyAddrs := make(map[common.Address]struct{})
-	for addr, account := range *diff {
+	for _, addr := range addrs {
+		account := (*diff)[addr]
 		// If a precompile was moved to this address already, it can't be overridden.
 		if _, ok := dirtyAddrs[addr]; ok {
 			return fmt.Errorf("account %s has already been overridden by a precompile", addr.Hex())

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -17,11 +17,11 @@
 package override
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
-	"sort"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -61,11 +61,7 @@ func (diff *StateOverride) Apply(statedb *state.StateDB, precompiles vm.Precompi
 		return nil
 	}
 	// Iterate in deterministic order so error messages and behavior are stable (e.g. for tests).
-	addrs := make([]common.Address, 0, len(*diff))
-	for addr := range *diff {
-		addrs = append(addrs, addr)
-	}
-	sort.Slice(addrs, func(i, j int) bool { return bytes.Compare(addrs[i][:], addrs[j][:]) < 0 })
+	addrs := slices.SortedFunc(maps.Keys(*diff), common.Address.Cmp)
 
 	// Tracks destinations of precompiles that were moved.
 	dirtyAddrs := make(map[common.Address]struct{})

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -223,6 +223,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		withdrawals: args.Withdrawals,
 		beaconRoot:  args.BeaconRoot,
 		noTxs:       true,
+		extraData:   args.ExtraData,
 	}
 	empty := miner.generateWork(emptyParams, witness)
 	if empty.err != nil {
@@ -253,6 +254,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 			withdrawals: args.Withdrawals,
 			beaconRoot:  args.BeaconRoot,
 			noTxs:       false,
+			extraData:   args.ExtraData,
 		}
 
 		for {

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -246,15 +246,16 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		endTimer := time.NewTimer(time.Second * 12)
 
 		fullParams := &generateParams{
-			timestamp:   args.Timestamp,
-			forceTime:   true,
-			parentHash:  args.Parent,
-			coinbase:    args.FeeRecipient,
-			random:      args.Random,
-			withdrawals: args.Withdrawals,
-			beaconRoot:  args.BeaconRoot,
-			noTxs:       false,
-			extraData:   args.ExtraData,
+			timestamp:    args.Timestamp,
+			forceTime:    true,
+			parentHash:   args.Parent,
+			coinbase:     args.FeeRecipient,
+			random:       args.Random,
+			withdrawals:  args.Withdrawals,
+			beaconRoot:   args.BeaconRoot,
+			noTxs:        false,
+			extraData:    args.ExtraData,
+			transactions: args.Transactions,
 		}
 
 		for {

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -44,6 +44,10 @@ type BuildPayloadArgs struct {
 	Withdrawals  types.Withdrawals     // The provided withdrawals
 	BeaconRoot   *common.Hash          // The provided beaconRoot (Cancun)
 	Version      engine.PayloadVersion // Versioning byte for payload id calculation.
+
+	// Options for testing
+	Transactions []*types.Transaction
+	ExtraData    []byte
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -255,6 +255,9 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 	if args.OnlyProvidedTxs {
 		r := miner.generateWork(fullParams, witness)
 		if r.err != nil {
+			// Must return the error: testing API requires a block built with only the provided
+			// txs. Normal mining can return an empty payload and keep retrying in the background;
+			// we cannot—the caller must get the failure.
 			return nil, r.err
 		}
 		payload.update(r, 0)

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -46,8 +46,10 @@ type BuildPayloadArgs struct {
 	Version      engine.PayloadVersion // Versioning byte for payload id calculation.
 
 	// Options for testing
-	Transactions []*types.Transaction
-	ExtraData    []byte
+	Transactions     []*types.Transaction
+	ExtraData        []byte
+	OnlyProvidedTxs  bool // If true, use only Transactions (no mempool); empty list means empty block.
+	UseExplicitExtra bool // If true, use ExtraData verbatim (including empty) for header.Extra.
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -215,15 +217,16 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 	// enough to run. The empty payload can at least make sure there is something
 	// to deliver for not missing slot.
 	emptyParams := &generateParams{
-		timestamp:   args.Timestamp,
-		forceTime:   true,
-		parentHash:  args.Parent,
-		coinbase:    args.FeeRecipient,
-		random:      args.Random,
-		withdrawals: args.Withdrawals,
-		beaconRoot:  args.BeaconRoot,
-		noTxs:       true,
-		extraData:   args.ExtraData,
+		timestamp:            args.Timestamp,
+		forceTime:            true,
+		parentHash:           args.Parent,
+		coinbase:             args.FeeRecipient,
+		random:               args.Random,
+		withdrawals:          args.Withdrawals,
+		beaconRoot:           args.BeaconRoot,
+		noTxs:                true,
+		extraData:            args.ExtraData,
+		useExplicitExtraData: args.UseExplicitExtra,
 	}
 	empty := miner.generateWork(emptyParams, witness)
 	if empty.err != nil {
@@ -231,6 +234,32 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 	}
 	// Construct a payload object for return.
 	payload := newPayload(empty.block, empty.requests, empty.witness, args.Id())
+
+	fullParams := &generateParams{
+		timestamp:            args.Timestamp,
+		forceTime:            true,
+		parentHash:           args.Parent,
+		coinbase:             args.FeeRecipient,
+		random:               args.Random,
+		withdrawals:          args.Withdrawals,
+		beaconRoot:           args.BeaconRoot,
+		noTxs:                false,
+		extraData:            args.ExtraData,
+		transactions:         args.Transactions,
+		onlyProvidedTxs:      args.OnlyProvidedTxs,
+		useExplicitExtraData: args.UseExplicitExtra,
+	}
+
+	// When OnlyProvidedTxs (testing_buildBlockV1), build the full block synchronously
+	// so the returned payload has exactly the requested transactions and we don't use mempool.
+	if args.OnlyProvidedTxs {
+		r := miner.generateWork(fullParams, witness)
+		if r.err != nil {
+			return nil, r.err
+		}
+		payload.update(r, 0)
+		return payload, nil
+	}
 
 	// Spin up a routine for updating the payload in background. This strategy
 	// can maximum the revenue for including transactions with highest fee.
@@ -244,19 +273,6 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		// the Mainnet configuration) have passed since the point in time identified
 		// by the timestamp parameter.
 		endTimer := time.NewTimer(time.Second * 12)
-
-		fullParams := &generateParams{
-			timestamp:    args.Timestamp,
-			forceTime:    true,
-			parentHash:   args.Parent,
-			coinbase:     args.FeeRecipient,
-			random:       args.Random,
-			withdrawals:  args.Withdrawals,
-			beaconRoot:   args.BeaconRoot,
-			noTxs:        false,
-			extraData:    args.ExtraData,
-			transactions: args.Transactions,
-		}
 
 		for {
 			select {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -112,6 +112,9 @@ type generateParams struct {
 	withdrawals types.Withdrawals // List of withdrawals to include in block (shanghai field)
 	beaconRoot  *common.Hash      // The beacon root (cancun field).
 	noTxs       bool              // Flag whether an empty block without any transaction is expected
+
+	extraData    []byte
+	transactions []*types.Transaction
 }
 
 // generateWork generates a sealing block based on the given parameters.
@@ -132,16 +135,30 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 	work.size += uint64(genParam.withdrawals.Size())
 
 	if !genParam.noTxs {
-		interrupt := new(atomic.Int32)
-		timer := time.AfterFunc(miner.config.Recommit, func() {
-			interrupt.Store(commitInterruptTimeout)
-		})
-		defer timer.Stop()
+		if len(genParam.transactions) == 0 {
+			interrupt := new(atomic.Int32)
+			timer := time.AfterFunc(miner.config.Recommit, func() {
+				interrupt.Store(commitInterruptTimeout)
+			})
+			defer timer.Stop()
 
-		err := miner.fillTransactions(interrupt, work)
-		if errors.Is(err, errBlockInterruptedByTimeout) {
-			log.Warn("Block building is interrupted", "allowance", common.PrettyDuration(miner.config.Recommit))
+			err := miner.fillTransactions(interrupt, work)
+			if errors.Is(err, errBlockInterruptedByTimeout) {
+				log.Warn("Block building is interrupted", "allowance", common.PrettyDuration(miner.config.Recommit))
+			}
+		} else {
+			// if we have transactions available, we build a block only from them.
+			// this is only used during testing when we want to force a certain
+			// ordering of transactions.
+			if work.gasPool == nil {
+				work.gasPool = new(core.GasPool).AddGas(work.header.GasLimit)
+			}
+			for _, tx := range genParam.transactions {
+				work.state.SetTxContext(tx.Hash(), work.tcount)
+				miner.commitTransaction(work, tx)
+			}
 		}
+
 	}
 	body := types.Body{Transactions: work.txs, Withdrawals: genParam.withdrawals}
 
@@ -219,6 +236,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		GasLimit:   core.CalcGasLimit(parent.GasLimit, miner.config.GasCeil),
 		Time:       timestamp,
 		Coinbase:   genParams.coinbase,
+		Extra:      genParams.extraData,
 	}
 	// Set the extra field.
 	if len(miner.config.ExtraData) != 0 {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -158,7 +158,6 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 				miner.commitTransaction(work, tx)
 			}
 		}
-
 	}
 	body := types.Body{Transactions: work.txs, Withdrawals: genParam.withdrawals}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -236,11 +236,13 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		GasLimit:   core.CalcGasLimit(parent.GasLimit, miner.config.GasCeil),
 		Time:       timestamp,
 		Coinbase:   genParams.coinbase,
-		Extra:      genParams.extraData,
 	}
 	// Set the extra field.
 	if len(miner.config.ExtraData) != 0 {
 		header.Extra = miner.config.ExtraData
+	}
+	if len(genParams.extraData) != 0 {
+		header.Extra = genParams.extraData
 	}
 	// Set the randomness field from the beacon chain if it's available.
 	if genParams.random != (common.Hash{}) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -113,8 +113,10 @@ type generateParams struct {
 	beaconRoot  *common.Hash      // The beacon root (cancun field).
 	noTxs       bool              // Flag whether an empty block without any transaction is expected
 
-	extraData    []byte
-	transactions []*types.Transaction
+	extraData            []byte
+	transactions         []*types.Transaction
+	onlyProvidedTxs      bool // If true, use only transactions (no mempool); empty list = empty block
+	useExplicitExtraData bool // If true, set header.Extra to extraData even when empty
 }
 
 // generateWork generates a sealing block based on the given parameters.
@@ -136,15 +138,19 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 
 	if !genParam.noTxs {
 		if len(genParam.transactions) == 0 {
-			interrupt := new(atomic.Int32)
-			timer := time.AfterFunc(miner.config.Recommit, func() {
-				interrupt.Store(commitInterruptTimeout)
-			})
-			defer timer.Stop()
+			if genParam.onlyProvidedTxs {
+				// Testing path: empty list means empty block, do not use mempool.
+			} else {
+				interrupt := new(atomic.Int32)
+				timer := time.AfterFunc(miner.config.Recommit, func() {
+					interrupt.Store(commitInterruptTimeout)
+				})
+				defer timer.Stop()
 
-			err := miner.fillTransactions(interrupt, work)
-			if errors.Is(err, errBlockInterruptedByTimeout) {
-				log.Warn("Block building is interrupted", "allowance", common.PrettyDuration(miner.config.Recommit))
+				err := miner.fillTransactions(interrupt, work)
+				if errors.Is(err, errBlockInterruptedByTimeout) {
+					log.Warn("Block building is interrupted", "allowance", common.PrettyDuration(miner.config.Recommit))
+				}
 			}
 		} else {
 			// if we have transactions available, we build a block only from them.
@@ -155,7 +161,13 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 			}
 			for _, tx := range genParam.transactions {
 				work.state.SetTxContext(tx.Hash(), work.tcount)
-				miner.commitTransaction(work, tx)
+				if err := miner.commitTransaction(work, tx); err != nil {
+					if genParam.onlyProvidedTxs {
+						return &newPayloadResult{err: err}
+					}
+					// Non-testing path: skip invalid txs
+					log.Trace("Transaction failed, skipping", "hash", tx.Hash(), "err", err)
+				}
 			}
 		}
 	}
@@ -237,11 +249,15 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		Coinbase:   genParams.coinbase,
 	}
 	// Set the extra field.
-	if len(miner.config.ExtraData) != 0 {
-		header.Extra = miner.config.ExtraData
-	}
-	if len(genParams.extraData) != 0 {
+	if genParams.useExplicitExtraData {
 		header.Extra = genParams.extraData
+	} else {
+		if len(miner.config.ExtraData) != 0 {
+			header.Extra = miner.config.ExtraData
+		}
+		if len(genParams.extraData) != 0 {
+			header.Extra = genParams.extraData
+		}
 	}
 	// Set the randomness field from the beacon chain if it's available.
 	if genParams.random != (common.Hash{}) {

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -520,6 +520,9 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 
 	// If the method is not found, return an error.
 	if callb == nil {
+		for name := range h.reg.services {
+			fmt.Println(name)
+		}
 		return msg.errorResponse(&methodNotFoundError{method: msg.Method})
 	}
 


### PR DESCRIPTION
- miner: OnlyProvidedTxs/UseExplicitExtra for testing_buildBlockV1; sync payload when only provided txs
- eth/catalyst: BuildPayload with OnlyProvidedTxs and UseExplicitExtra for testing API
- eth/tracers/logger: sort access list addresses and storage keys for deterministic eth_createAccessList
- internal/ethapi/override: sort addresses for deterministic state override error messages
- cmd/geth: expect testing:1.0 in console IPC APIs