### PR TITLE
testing: add mempool support to testing_buildBlockV1

### DIFF
--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/node"
@@ -32,21 +33,37 @@ func RegisterTestingAPI(stack *node.Node, backend *eth.Ethereum) error {
 	return nil
 }
 
-func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions []hexutil.Bytes, extraData *hexutil.Bytes) (*engine.ExecutionPayloadEnvelope, error) {
+func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes engine.PayloadAttributes, transactions *[]hexutil.Bytes, extraData *hexutil.Bytes) (*engine.ExecutionPayloadEnvelope, error) {
 	if api.eth.BlockChain().CurrentBlock().Hash() != parentHash {
 		return nil, errors.New("parentHash is not current head")
 	}
-	dec := make([][]byte, 0, len(transactions))
-	for _, tx := range transactions {
-		dec = append(dec, tx)
+
+	// Determine whether to force override transactions or build from mempool
+	var txs []*types.Transaction
+	var forceOverride bool
+
+	if transactions == nil {
+		// null transactions: build from mempool
+		forceOverride = false
+		txs = nil
+	} else {
+		// empty array or non-empty array: force override with specified transactions
+		forceOverride = true
+		dec := make([][]byte, 0, len(*transactions))
+		for _, tx := range *transactions {
+			dec = append(dec, tx)
+		}
+		var err error
+		txs, err = engine.DecodeTransactions(dec)
+		if err != nil {
+			return nil, err
+		}
 	}
-	txs, err := engine.DecodeTransactions(dec)
-	if err != nil {
-		return nil, err
-	}
-	extra := make([]byte, 0)
+
+	var extra *[]byte
 	if extraData != nil {
-		extra = *extraData
+		extraBytes := []byte(*extraData)
+		extra = &extraBytes
 	}
 	args := &miner.BuildPayloadArgs{
 		Parent:       parentHash,
@@ -56,5 +73,5 @@ func (api *TestingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 		Withdrawals:  payloadAttributes.Withdrawals,
 		BeaconRoot:   payloadAttributes.BeaconRoot,
 	}
-	return api.eth.Miner().BuildTestingPayload(args, txs, extra)
+	return api.eth.Miner().BuildTestingPayload(args, txs, extra, forceOverride)
 }

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -274,7 +274,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 	return payload, nil
 }
 
-func (miner *Miner) BuildTestingPayload(args *BuildPayloadArgs, transactions []*types.Transaction, extraData []byte) (*engine.ExecutionPayloadEnvelope, error) {
+func (miner *Miner) BuildTestingPayload(args *BuildPayloadArgs, transactions []*types.Transaction, extraData *[]byte, forceOverride bool) (*engine.ExecutionPayloadEnvelope, error) {
 	fullParams := &generateParams{
 		timestamp:         args.Timestamp,
 		forceTime:         true,
@@ -284,7 +284,7 @@ func (miner *Miner) BuildTestingPayload(args *BuildPayloadArgs, transactions []*
 		withdrawals:       args.Withdrawals,
 		beaconRoot:        args.BeaconRoot,
 		noTxs:             false,
-		forceOverrides:    true,
+		forceOverrides:    forceOverride,
 		overrideExtraData: extraData,
 		overrideTxs:       transactions,
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -113,8 +113,8 @@ type generateParams struct {
 	beaconRoot  *common.Hash      // The beacon root (cancun field).
 	noTxs       bool              // Flag whether an empty block without any transaction is expected
 
-	forceOverrides    bool // Flag whether we should overwrite extraData and transactions
-	overrideExtraData []byte
+	forceOverrides    bool // Flag whether we should overwrite transactions
+	overrideExtraData *[]byte
 	overrideTxs       []*types.Transaction
 }
 
@@ -238,11 +238,10 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		Coinbase:   genParams.coinbase,
 	}
 	// Set the extra field.
-	if len(miner.config.ExtraData) != 0 {
+	if genParams.overrideExtraData != nil {
+		header.Extra = *genParams.overrideExtraData
+	} else if len(miner.config.ExtraData) != 0 {
 		header.Extra = miner.config.ExtraData
-	}
-	if genParams.forceOverrides {
-		header.Extra = genParams.overrideExtraData
 	}
 	// Set the randomness field from the beacon chain if it's available.
 	if genParams.random != (common.Hash{}) {


### PR DESCRIPTION
Allow null transactions parameter to build blocks from mempool.
- transactions = [] builds empty block
- transactions = null builds from mempool
- transactions = [...] builds with specified txs only

Separate extraData override from transaction override for deterministic cross-client testing.