### PR TITLE
core, beacon/engine, core/txpool, miner: bring bal-devnet-4 back to life

### DIFF
--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
 )
 
 var _ = (*executableDataMarshaling)(nil)
@@ -17,24 +18,25 @@ var _ = (*executableDataMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	type ExecutableData struct {
-		ParentHash    common.Hash         `json:"parentHash"    gencodec:"required"`
-		FeeRecipient  common.Address      `json:"feeRecipient"  gencodec:"required"`
-		StateRoot     common.Hash         `json:"stateRoot"     gencodec:"required"`
-		ReceiptsRoot  common.Hash         `json:"receiptsRoot"  gencodec:"required"`
-		LogsBloom     hexutil.Bytes       `json:"logsBloom"     gencodec:"required"`
-		Random        common.Hash         `json:"prevRandao"    gencodec:"required"`
-		Number        hexutil.Uint64      `json:"blockNumber"   gencodec:"required"`
-		GasLimit      hexutil.Uint64      `json:"gasLimit"      gencodec:"required"`
-		GasUsed       hexutil.Uint64      `json:"gasUsed"       gencodec:"required"`
-		Timestamp     hexutil.Uint64      `json:"timestamp"     gencodec:"required"`
-		ExtraData     hexutil.Bytes       `json:"extraData"     gencodec:"required"`
-		BaseFeePerGas *hexutil.Big        `json:"baseFeePerGas" gencodec:"required"`
-		BlockHash     common.Hash         `json:"blockHash"     gencodec:"required"`
-		Transactions  []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
-		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
-		BlobGasUsed   *hexutil.Uint64     `json:"blobGasUsed"`
-		ExcessBlobGas *hexutil.Uint64     `json:"excessBlobGas"`
-		SlotNumber    *hexutil.Uint64     `json:"slotNumber,omitempty"`
+		ParentHash      common.Hash          `json:"parentHash"    gencodec:"required"`
+		FeeRecipient    common.Address       `json:"feeRecipient"  gencodec:"required"`
+		StateRoot       common.Hash          `json:"stateRoot"     gencodec:"required"`
+		ReceiptsRoot    common.Hash          `json:"receiptsRoot"  gencodec:"required"`
+		LogsBloom       hexutil.Bytes        `json:"logsBloom"     gencodec:"required"`
+		Random          common.Hash          `json:"prevRandao"    gencodec:"required"`
+		Number          hexutil.Uint64       `json:"blockNumber"   gencodec:"required"`
+		GasLimit        hexutil.Uint64       `json:"gasLimit"      gencodec:"required"`
+		GasUsed         hexutil.Uint64       `json:"gasUsed"       gencodec:"required"`
+		Timestamp       hexutil.Uint64       `json:"timestamp"     gencodec:"required"`
+		ExtraData       hexutil.Bytes        `json:"extraData"     gencodec:"required"`
+		BaseFeePerGas   *hexutil.Big         `json:"baseFeePerGas" gencodec:"required"`
+		BlockHash       common.Hash          `json:"blockHash"     gencodec:"required"`
+		Transactions    []hexutil.Bytes      `json:"transactions"  gencodec:"required"`
+		Withdrawals     []*types.Withdrawal  `json:"withdrawals"`
+		BlobGasUsed     *hexutil.Uint64      `json:"blobGasUsed"`
+		ExcessBlobGas   *hexutil.Uint64      `json:"excessBlobGas"`
+		BlockAccessList *bal.BlockAccessList `json:"blockAccessList"`
+		SlotNumber      *hexutil.Uint64      `json:"slotNumber,omitempty"`
 	}
 	var enc ExecutableData
 	enc.ParentHash = e.ParentHash
@@ -59,6 +61,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	enc.Withdrawals = e.Withdrawals
 	enc.BlobGasUsed = (*hexutil.Uint64)(e.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(e.ExcessBlobGas)
+	enc.BlockAccessList = e.BlockAccessList
 	enc.SlotNumber = (*hexutil.Uint64)(e.SlotNumber)
 	return json.Marshal(&enc)
 }
@@ -66,24 +69,25 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	type ExecutableData struct {
-		ParentHash    *common.Hash        `json:"parentHash"    gencodec:"required"`
-		FeeRecipient  *common.Address     `json:"feeRecipient"  gencodec:"required"`
-		StateRoot     *common.Hash        `json:"stateRoot"     gencodec:"required"`
-		ReceiptsRoot  *common.Hash        `json:"receiptsRoot"  gencodec:"required"`
-		LogsBloom     *hexutil.Bytes      `json:"logsBloom"     gencodec:"required"`
-		Random        *common.Hash        `json:"prevRandao"    gencodec:"required"`
-		Number        *hexutil.Uint64     `json:"blockNumber"   gencodec:"required"`
-		GasLimit      *hexutil.Uint64     `json:"gasLimit"      gencodec:"required"`
-		GasUsed       *hexutil.Uint64     `json:"gasUsed"       gencodec:"required"`
-		Timestamp     *hexutil.Uint64     `json:"timestamp"     gencodec:"required"`
-		ExtraData     *hexutil.Bytes      `json:"extraData"     gencodec:"required"`
-		BaseFeePerGas *hexutil.Big        `json:"baseFeePerGas" gencodec:"required"`
-		BlockHash     *common.Hash        `json:"blockHash"     gencodec:"required"`
-		Transactions  []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
-		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
-		BlobGasUsed   *hexutil.Uint64     `json:"blobGasUsed"`
-		ExcessBlobGas *hexutil.Uint64     `json:"excessBlobGas"`
-		SlotNumber    *hexutil.Uint64     `json:"slotNumber,omitempty"`
+		ParentHash      *common.Hash         `json:"parentHash"    gencodec:"required"`
+		FeeRecipient    *common.Address      `json:"feeRecipient"  gencodec:"required"`
+		StateRoot       *common.Hash         `json:"stateRoot"     gencodec:"required"`
+		ReceiptsRoot    *common.Hash         `json:"receiptsRoot"  gencodec:"required"`
+		LogsBloom       *hexutil.Bytes       `json:"logsBloom"     gencodec:"required"`
+		Random          *common.Hash         `json:"prevRandao"    gencodec:"required"`
+		Number          *hexutil.Uint64      `json:"blockNumber"   gencodec:"required"`
+		GasLimit        *hexutil.Uint64      `json:"gasLimit"      gencodec:"required"`
+		GasUsed         *hexutil.Uint64      `json:"gasUsed"       gencodec:"required"`
+		Timestamp       *hexutil.Uint64      `json:"timestamp"     gencodec:"required"`
+		ExtraData       *hexutil.Bytes       `json:"extraData"     gencodec:"required"`
+		BaseFeePerGas   *hexutil.Big         `json:"baseFeePerGas" gencodec:"required"`
+		BlockHash       *common.Hash         `json:"blockHash"     gencodec:"required"`
+		Transactions    []hexutil.Bytes      `json:"transactions"  gencodec:"required"`
+		Withdrawals     []*types.Withdrawal  `json:"withdrawals"`
+		BlobGasUsed     *hexutil.Uint64      `json:"blobGasUsed"`
+		ExcessBlobGas   *hexutil.Uint64      `json:"excessBlobGas"`
+		BlockAccessList *bal.BlockAccessList `json:"blockAccessList"`
+		SlotNumber      *hexutil.Uint64      `json:"slotNumber,omitempty"`
 	}
 	var dec ExecutableData
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -156,6 +160,9 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ExcessBlobGas != nil {
 		e.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.BlockAccessList != nil {
+		e.BlockAccessList = dec.BlockAccessList
 	}
 	if dec.SlotNumber != nil {
 		e.SlotNumber = (*uint64)(dec.SlotNumber)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -556,6 +556,9 @@ func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
 			if head.SlotNumber == nil {
 				head.SlotNumber = new(uint64)
 			}
+			if head.BlockAccessListHash == nil {
+				head.BlockAccessListHash = &types.EmptyBlockAccessListHash
+			}
 		}
 	}
 	return types.NewBlock(head, &types.Body{Withdrawals: withdrawals}, nil, trie.NewStackTrie(nil))

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -134,8 +134,8 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		// We require transactions to pay for 110% of intrinsic gas in order to
 		// prevent situations where a change in gas limit invalidates a lot
 		// of transactions in the txpool
-		if tx.Gas() < (intrGas.RegularGas*10)/9 {
-			return fmt.Errorf("%w: gas %v, minimum needed %v", core.ErrIntrinsicGas, tx.Gas(), intrGas.RegularGas)
+		if minGas := (intrGas.RegularGas * 10) / 9; tx.Gas() < minGas {
+			return fmt.Errorf("%w: gas %v, minimum needed %v", core.ErrIntrinsicGas, tx.Gas(), minGas)
 		}
 	}
 	if tx.Gas() < intrGas.RegularGas {

--- a/core/types/hashes.go
+++ b/core/types/hashes.go
@@ -43,6 +43,10 @@ var (
 	// EmptyRequestsHash is the known hash of an empty request set, sha256("").
 	EmptyRequestsHash = common.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 
+	// EmptyBlockAccessListHash is the known hash of an empty block access list,
+	// keccak256(rlp(empty list)) = keccak256(0xc0).
+	EmptyBlockAccessListHash = common.HexToHash("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+
 	// EmptyBinaryHash is the known hash of an empty binary trie.
 	EmptyBinaryHash = common.Hash{}
 )

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -151,11 +151,23 @@ func (miner *Miner) getPending() *newPayloadResult {
 		return cached
 	}
 	var (
-		timestamp  = uint64(time.Now().Unix())
-		withdrawal types.Withdrawals
+		timestamp   = uint64(time.Now().Unix())
+		childNumber = new(big.Int).Add(header.Number, big.NewInt(1))
+		withdrawal  types.Withdrawals
+		slotNum     *uint64
 	)
-	if miner.chainConfig.IsShanghai(new(big.Int).Add(header.Number, big.NewInt(1)), timestamp) {
+	if miner.chainConfig.IsShanghai(childNumber, timestamp) {
 		withdrawal = []*types.Withdrawal{}
+	}
+	// Post-Amsterdam, prepareWork requires a slot number (EIP-7843). The pending
+	// block is synthetic and has no canonical slot, so derive one from the parent
+	// when available and fall back to zero otherwise.
+	if miner.chainConfig.IsAmsterdam(childNumber, timestamp) {
+		var n uint64
+		if header.SlotNumber != nil {
+			n = *header.SlotNumber + 1
+		}
+		slotNum = &n
 	}
 	ret := miner.generateWork(context.Background(),
 		&generateParams{
@@ -166,6 +178,7 @@ func (miner *Miner) getPending() *newPayloadResult {
 			random:      common.Hash{},
 			withdrawals: withdrawal,
 			beaconRoot:  nil,
+			slotNum:     slotNum,
 			noTxs:       false,
 		}, false) // we will never make a witness for a pending block
 	if ret.err != nil {


### PR DESCRIPTION
Four bugs surfaced while running a kurtosis devnet (`gloas_fork_epoch: 0`, geth + Prysm) against `bal-devnet-4`. First two keep the chain from advancing past genesis; last two break user-facing RPCs (`eth_sendRawTransaction` error message, and every `pending`-tag query). All fixed here.

## 1. `core`: set empty `BlockAccessListHash` on Amsterdam genesis

`(*Genesis).toBlockWithRoot` populates `SlotNumber` but leaves `BlockAccessListHash` nil. Both are `rlp:\"optional\"`, and `BlockAccessListHash` comes first — RLP writes a 0-byte placeholder for it, and read-back fails:

```
Invalid block header RLP hash=... err=\"rlp: input string too short for
    common.Hash, decoding into (types.Header).BlockAccessListHash\"
Fatal: Failed to register the Ethereum service: genesis not found in chain
```

Fix: default `head.BlockAccessListHash` to `&types.EmptyBlockAccessListHash` under the Amsterdam fork gate, mirroring the Prague `RequestsHash` pattern. Adds the constant (`keccak256(rlp(empty list)) = 0x1dcc4de8…49347`) alongside the other `Empty*Hash` values.

Port of ethereum/go-ethereum#34774 (merged into `glamsterdam-devnet-0`).

## 2. `beacon/engine`: regenerate `gen_ed.go` to include `BlockAccessList`

With fix 1 applied, geth starts and slot-1 `engine_forkchoiceUpdatedV4` + `engine_getPayloadV6` succeed, but Prysm rejects the returned payload:

```
Could not get local payload: ... got an unexpected error in JSON-RPC
response: missing required field 'blockAccessList' for ExecutionPayload
slot=1 validator=95
```

`ExecutableData.BlockAccessList` exists in `types.go` but `gen_ed.go` was never regenerated — its `MarshalJSON`/`UnmarshalJSON` silently drop the field. Geth emits the payload without `blockAccessList`, Prysm rejects it, no block is published. From slot 2 onward Prysm reads the genesis block's zero `signed_execution_payload_bid.block_hash` as the head, geth refuses (\"Forkchoice requested update to zero hash\"), and the chain never advances.

`glamsterdam-devnet-0` carries the regenerated file (hence it works there); `bal-devnet-4` was missing it.

Fix: `go generate ./beacon/engine/`. No hand edits.

## 3. `core/txpool`: report actual 110% threshold in intrinsic-gas error

When EIP-8037 is active (`gasCostPerStateByte != 0`), txpool admission requires `tx.Gas() >= ceil(intrGas.RegularGas * 10/9)`, but the error message reports `intrGas.RegularGas` — the unscaled value. Submitting a plain 21000-gas transfer against this branch yields:

```
intrinsic gas too low: gas 21000, minimum needed 21000
```

which reads as \"21000 ≥ 21000 so why is this failing?\"  The real threshold is 23334. Observed in the enclave spamoor logs.

Fix: compute the threshold once and report it. After the change: `intrinsic gas too low: gas 21000, minimum needed 23333`.

Port of ethereum/go-ethereum#34782 (still open against `glamsterdam-devnet-0`).

## 4. `miner`: supply a slot number when synthesising pending block post-Amsterdam

`miner.getPending()` builds the pending block on demand via `generateWork`. After EIP-7843 (#33589), `prepareWork` rejects the call unless `generateParams.slotNum` is non-nil once Amsterdam is active:

```go
if miner.chainConfig.IsAmsterdam(header.Number, header.Time) {
    if genParams.slotNum == nil {
        return nil, errors.New(\"no slot number set post-amsterdam\")
    }
    header.SlotNumber = genParams.slotNum
}
```

`getPending` was never updated, so every RPC that resolves through the pending state fails with `pending state is not available`:

```
eth_getBalance(addr, \"pending\")         -> -32000 \"pending state is not available\"
eth_call({...}, \"pending\")              -> -32000 \"pending state is not available\"
eth_getBlockByNumber(\"pending\", ...)    -> -32000 \"pending block is not available\"
```

Faucets, nonce trackers, gas estimators, simulators — anything polling `pending` — are broken on this devnet.

Fix: synthesise a slot number from the parent header (`header.SlotNumber + 1`, falling back to `0` when unset) when Amsterdam is active for the next block, mirroring the existing Shanghai branch. The pending block is empty post-merge so the exact slot value is not user-visible; it just has to satisfy `prepareWork`'s invariant.

Port of ethereum/go-ethereum#34792 (open against `master`, with companion PRs #34790 against `bal-devnet-3` and #34791 against `glamsterdam-devnet-0`).

## Test plan

- [x] `go test ./core/ -run TestGenesis -count=1`
- [x] `go test ./beacon/engine/ -count=1`
- [x] `go test ./miner/... -count=1`
- [x] `go build ./...`
- [ ] Kurtosis run with `gloas_fork_epoch: 0` + Prysm `v1.7.0-alpha.5-minimal` + geth from this branch:
  - chain advances past genesis (fixes 1 & 2)
  - spamoor 21000-gas transfers either accepted or report the correct threshold (fix 3)
  - `eth_getBalance(addr, \"pending\")` returns a balance instead of an error (fix 4)