### PR TITLE
eth/engineapi: finish fork-gating for pre-Amsterdam SSZ engine API

### DIFF
--- a/beacon/engine/ssz/envelopes.go
+++ b/beacon/engine/ssz/envelopes.go
@@ -125,23 +125,27 @@ type ForkchoiceUpdateAmsterdam struct {
 }
 
 func (f *ForkchoiceUpdateAmsterdam) SizeSSZ(siz *ssz.Sizer, fixed bool) uint32 {
-	// 96 (state) + 4(offset attrs) + 4(offset custody)
-	size := uint32(96 + 8)
+	size := uint32(96 + 4) // state + attrs offset
+	if siz.Fork() >= forkAmsterdam {
+		size += 4 // custody offset (Amsterdam+)
+	}
 	if fixed {
 		return size
 	}
 	size += ssz.SizeSliceOfDynamicObjects(siz, f.PayloadAttributes)
-	size += ssz.SizeSliceOfStaticObjects(siz, f.CustodyColumns)
+	if siz.Fork() >= forkAmsterdam {
+		size += ssz.SizeSliceOfStaticObjects(siz, f.CustodyColumns)
+	}
 	return size
 }
 
 func (f *ForkchoiceUpdateAmsterdam) DefineSSZ(c *ssz.Codec) {
 	ssz.DefineStaticObject(c, &f.ForkchoiceState)
 	ssz.DefineSliceOfDynamicObjectsOffset(c, &f.PayloadAttributes, 1)
-	ssz.DefineSliceOfStaticObjectsOffset(c, &f.CustodyColumns, 1)
+	ssz.DefineSliceOfStaticObjectsOffsetOnFork(c, &f.CustodyColumns, 1, fromAmsterdam)
 
 	ssz.DefineSliceOfDynamicObjectsContent(c, &f.PayloadAttributes, 1)
-	ssz.DefineSliceOfStaticObjectsContent(c, &f.CustodyColumns, 1)
+	ssz.DefineSliceOfStaticObjectsContentOnFork(c, &f.CustodyColumns, 1, fromAmsterdam)
 }
 
 // Validate enforces the Optional[T] = List[T,1] length invariants.

--- a/eth/engineapi/forkchoice.go
+++ b/eth/engineapi/forkchoice.go
@@ -26,9 +26,9 @@ import (
 
 // handleForkchoice implements POST /engine/v2/{fork}/forkchoice.
 func (rt *Router) handleForkchoice(w http.ResponseWriter, r *http.Request, fork forks.Fork) {
-	// The execution-apis spec currently only defines the forkchoice envelope
-	// for Amsterdam; the inner attributes shape is fork-driven by the codec.
-	sf, ok := resolveFork(w, fork, forks.Amsterdam)
+	// The Amsterdam forkchoice envelope is the universal wire shape; the inner
+	// attributes are fork-driven by the codec down to Paris.
+	sf, ok := resolveFork(w, fork, forks.Paris)
 	if !ok {
 		return
 	}
@@ -48,11 +48,9 @@ func (rt *Router) handleForkchoice(w http.ResponseWriter, r *http.Request, fork 
 			writeProblem(w, http.StatusBadRequest, ErrInvalidAttributes, err.Error())
 			return
 		}
-		// If PayloadAttributes is present the URL fork MUST match the fork
-		// the new payload would belong to. Today only Amsterdam URL exists
-		// in this implementation so the timestamp check is implicit; we
-		// keep an explicit guard for future fork URLs.
-		if rt.backend.ForkFromTimestamp(attr.Timestamp) != fork {
+		// The URL fork must match the fork of the payload being built; collapse
+		// BPO forks onto their base fork since they share an engine-API URL.
+		if baseEngineFork(rt.backend.ForkFromTimestamp(attr.Timestamp)) != fork {
 			writeProblem(w, http.StatusBadRequest, ErrUnsupportedFork,
 				"payload_attributes timestamp does not match URL fork")
 			return
@@ -64,7 +62,7 @@ func (rt *Router) handleForkchoice(w http.ResponseWriter, r *http.Request, fork 
 		// underlying miner gains the corresponding setting.
 	}
 
-	resp, err := rt.backend.ForkchoiceUpdated(r.Context(), state, attrs, engine.PayloadV4)
+	resp, err := rt.backend.ForkchoiceUpdated(r.Context(), state, attrs, payloadVersionForFork(fork))
 	if err != nil {
 		mapBackendErr(w, err)
 		return
@@ -80,4 +78,18 @@ func (rt *Router) handleForkchoice(w http.ResponseWriter, r *http.Request, fork 
 		out.PayloadID = [][8]byte{[8]byte(*resp.PayloadID)}
 	}
 	writeSSZResponse(w, out, sf)
+}
+
+// payloadVersionForFork maps a fork to its forkchoiceUpdated PayloadVersion.
+func payloadVersionForFork(f forks.Fork) engine.PayloadVersion {
+	switch {
+	case f >= forks.Amsterdam:
+		return engine.PayloadV4
+	case f >= forks.Cancun:
+		return engine.PayloadV3
+	case f >= forks.Shanghai:
+		return engine.PayloadV2
+	default:
+		return engine.PayloadV1
+	}
 }

--- a/eth/engineapi/forkresolve.go
+++ b/eth/engineapi/forkresolve.go
@@ -39,3 +39,23 @@ func resolveFork(w http.ResponseWriter, fork, min forks.Fork) (ssz.Fork, bool) {
 	}
 	return sf, true
 }
+
+// baseEngineFork collapses Blob-Parameter-Only forks (BPO1..BPO5) onto their
+// base protocol fork (Osaka), which is the one with a fork-scoped engine URL.
+func baseEngineFork(f forks.Fork) forks.Fork {
+	switch f {
+	case forks.BPO1, forks.BPO2, forks.BPO3, forks.BPO4, forks.BPO5:
+		return forks.Osaka
+	default:
+		return f
+	}
+}
+
+// eraForks returns the fork plus the BPO forks layered on it, for validating a
+// built payload's timestamp-derived fork (which LatestFork may report as a BPO).
+func eraForks(fork forks.Fork) []forks.Fork {
+	if fork == forks.Osaka {
+		return []forks.Fork{forks.Osaka, forks.BPO1, forks.BPO2, forks.BPO3, forks.BPO4, forks.BPO5}
+	}
+	return []forks.Fork{fork}
+}

--- a/eth/engineapi/get_payload.go
+++ b/eth/engineapi/get_payload.go
@@ -29,7 +29,7 @@ import (
 
 // handleGetPayload implements GET /engine/v2/{fork}/payloads/{payloadId}.
 func (rt *Router) handleGetPayload(w http.ResponseWriter, r *http.Request, fork forks.Fork, idHex string) {
-	sf, ok := resolveFork(w, fork, forks.Amsterdam)
+	sf, ok := resolveFork(w, fork, forks.Paris)
 	if !ok {
 		return
 	}
@@ -41,7 +41,7 @@ func (rt *Router) handleGetPayload(w http.ResponseWriter, r *http.Request, fork 
 	var id engine.PayloadID
 	copy(id[:], raw)
 
-	env, err := rt.backend.GetPayload(id, []forks.Fork{forks.Amsterdam})
+	env, err := rt.backend.GetPayload(id, eraForks(fork))
 	if err != nil {
 		mapBackendErr(w, err)
 		return

--- a/eth/engineapi/payloads.go
+++ b/eth/engineapi/payloads.go
@@ -27,9 +27,9 @@ import (
 
 // handleNewPayload implements POST /engine/v2/{fork}/payloads.
 func (rt *Router) handleNewPayload(w http.ResponseWriter, r *http.Request, fork forks.Fork) {
-	// The execution-apis spec currently only defines the payload envelope for
-	// Amsterdam; the inner payload shape is fork-driven by the codec.
-	sf, ok := resolveFork(w, fork, forks.Amsterdam)
+	// The Amsterdam payload envelope is the universal wire shape; the inner
+	// payload is fork-driven by the codec down to Paris.
+	sf, ok := resolveFork(w, fork, forks.Paris)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
Follow-up to my comment on #35171 — the five fork-gating fixes, validated locally.

`afa27a4f "advertise all forks"` made `capabilities` advertise `paris…osaka`, but several handlers/wrappers were still gated to Amsterdam, so SSZ calls for those forks failed at five points. Found by running the branch on a minimal-preset Osaka/fulu devnet (BPO1@genesis) against **two independent SSZ-engine clients** — prysm (`--engine-ssz-http`) and consensoor — which both failed identically until each fix.

| Fix | Symptom |
|---|---|
| `forkchoice`/`payloads`/`get_payload`: `resolveFork` min `Amsterdam`→`Paris` (`bodies.go` already used Paris) | `400 unsupported-fork` |
| `ForkchoiceUpdateAmsterdam`: fork-gate `CustodyColumns` (`…OnFork`, like `PayloadAttributes`) | `400 ssz-decode-error` |
| forkchoice timestamp guard: collapse BPO forks onto their base fork (`LatestFork` returns `BPO1` for an Osaka chain) | `400 unsupported-fork: timestamp` |
| forkchoice: `PayloadVersion` by fork instead of hardcoded `engine.PayloadV4` (V4 requires `slot_number`) | `500 Invalid payload attributes` on every proposal |
| `get_payload`: pass the URL fork's era (incl. BPO) to `allowedForks` | `400 unsupported-fork` on getPayload |

After these, both clients drive the full Osaka SSZ path (forkchoice, newPayload, getPayload, proposals) with 200s. `go build` + `go test ./eth/engineapi/... ./beacon/engine/ssz/...` pass. Diff is +55/-19 across 5 files.

There's also a test gap worth a follow-up (not in this PR): `TestRouterCapabilities` asserts cancun/osaka are advertised while `TestRouterUnsupportedFork` asserts `/cancun/payloads`→400, and nothing asserts an advertised fork is actually routable — so CI stayed green. Happy to add a positive routing test if you want it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
